### PR TITLE
Add default module templates and update generator

### DIFF
--- a/generate_project.py
+++ b/generate_project.py
@@ -1,5 +1,8 @@
 import os
 from pathlib import Path
+import shutil
+
+TEMPLATE_DIR = Path(__file__).parent / "templates"
 
 def create_project(nom_site, slug, couleur="#00838f"):
     base = Path(slug)
@@ -10,8 +13,16 @@ def create_project(nom_site, slug, couleur="#00838f"):
         base / "instance"
     ]
 
+
     for folder in folders:
         folder.mkdir(parents=True, exist_ok=True)
+
+    # Copier les modules Python de base depuis TEMPLATE_DIR
+    for filename in ["utils.py", "config.py", "models.py"]:
+        src = TEMPLATE_DIR / filename
+        dst = base / filename
+        if src.exists():
+            shutil.copy(src, dst)
 
     # app.py
     (base / "app.py").write_text("""import os
@@ -199,7 +210,11 @@ header {{ background-color: {couleur}; color: white; padding: 10px 20px; display
     (base / "README.md").write_text(f"# {nom_site}\n\nCe site est généré automatiquement.\n\n- Couleur principale : {couleur}\n- Dossier : {slug}\n")
 
     # .gitignore, Procfile, requirements.txt
-    (base / "requirements.txt").write_text("Flask")
+    (base / "requirements.txt").write_text("\n".join([
+        "Flask",
+        "Flask-Mail",
+        "Flask-SQLAlchemy"
+    ]))
     (base / "Procfile").write_text("web: gunicorn app:app")
     (base / ".gitignore").write_text("instance/\n*.db\n__pycache__/\n.env")
 

--- a/templates/config.py
+++ b/templates/config.py
@@ -1,0 +1,12 @@
+# Configuration par défaut du site
+
+SECRET_KEY = "change-this-secret-key"
+SQLALCHEMY_DATABASE_URI = "sqlite:///instance/site.db"
+ADMIN_USERNAME = "admin"
+# Mot de passe haché par werkzeug.security.generate_password_hash("password")
+ADMIN_PASSWORD_HASH = "pbkdf2:sha256:260000$changeme$1234567890abcdef"
+
+# Configuration Flask-Mail (serveur local par défaut)
+MAIL_SERVER = 'localhost'
+MAIL_PORT = 25
+MAIL_DEFAULT_SENDER = 'noreply@example.com'

--- a/templates/models.py
+++ b/templates/models.py
@@ -1,0 +1,19 @@
+from flask_sqlalchemy import SQLAlchemy
+
+# Instance de la base de données
+# Elle sera initialisée par l'application Flask
+
+db = SQLAlchemy()
+
+
+class Reservation(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    nom = db.Column(db.String(120), nullable=False)
+    prenom = db.Column(db.String(120), nullable=False)
+    email = db.Column(db.String(255), nullable=False)
+    service = db.Column(db.String(255), nullable=False)
+    date = db.Column(db.String(50), nullable=False)
+    heure = db.Column(db.String(50), nullable=False)
+
+    def __repr__(self):
+        return f"<Reservation {self.nom} {self.prenom} - {self.service}>"

--- a/templates/utils.py
+++ b/templates/utils.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+"""Fonctions utilitaires pour la génération de sites."""
+
+import csv
+from flask_mail import Mail, Message
+
+mail = Mail()
+
+
+def enregistrer_csv(row, fichier="instance/reservations.csv"):
+    """Enregistre une ligne dans un fichier CSV."""
+    with open(fichier, "a", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(row)
+
+
+def init_mail(app):
+    """Initialise l'extension Flask-Mail avec l'application donnée."""
+    mail.init_app(app)
+
+
+def envoyer_mail(prenom, dest, service, date, heure):
+    """Envoie un e-mail de confirmation simple."""
+    msg = Message(
+        subject=f"Confirmation de rendez-vous pour {service}",
+        recipients=[dest],
+        body=(
+            f"Bonjour {prenom},\n\n"
+            f"Votre demande de rendez-vous pour '{service}' le {date} à {heure} "
+            "a bien été reçue.\n"
+        ),
+    )
+    mail.send(msg)


### PR DESCRIPTION
## Summary
- provide reusable Python templates for utils, config, and models
- copy those templates when generating a project
- include Flask-Mail and Flask-SQLAlchemy in requirements

## Testing
- `python -m py_compile templates/utils.py templates/config.py templates/models.py generate_project.py`

------
https://chatgpt.com/codex/tasks/task_e_68470b6604cc8330b46406d52c311915